### PR TITLE
Add method for setting the toolbar title

### DIFF
--- a/src/main/java/com/flowingcode/addons/applayout/AppLayout.java
+++ b/src/main/java/com/flowingcode/addons/applayout/AppLayout.java
@@ -93,6 +93,11 @@ public class AppLayout extends Div implements PageConfigurator {
 		return drawer.isVisible();
 	}
 
+	/**Set the toolbar title*/
+	public void setCaption(String caption) {
+		header.getAppToolbar().setTitle(caption);
+	}
+
 	@Override
 	public void configurePage(InitialPageSettings settings) {
         settings.addMetaTag("viewport", "width=device-width, initial-scale=1.0");

--- a/src/main/java/com/flowingcode/addons/applayout/AppToolbar.java
+++ b/src/main/java/com/flowingcode/addons/applayout/AppToolbar.java
@@ -58,12 +58,14 @@ public class AppToolbar extends Component implements HasComponents {
     		ctitle = logo;
     		this.add(ctitle);
     	}
-    	if (title!=null) {
-        	divTitle = new Div();
-        	divTitle.setText(title);
-        	divTitle.getElement().setAttribute("main-title", true);
-    		this.add(divTitle);
-    	}
+    	divTitle = new Div();
+    	divTitle.getElement().setAttribute("main-title", true);
+    	this.add(divTitle);
+    	setTitle(title);
+    }
+
+    public void setTitle(String title) {
+    	divTitle.setText(title);
     }
 
 	public void setToolbarIconButtons(MenuItem[] menuItems) {


### PR DESCRIPTION
Fixes #20 by providing methods `setCaption` in `AppLayout` and `setTitle` in `AppToolbar`. `AppToolbar` was also modified so that it always has a `divTitle` element (even when it is empty).