### PR TITLE
Allow configuration of fixed and reveals properties

### DIFF
--- a/src/main/java/com/flowingcode/addons/applayout/AppHeader.java
+++ b/src/main/java/com/flowingcode/addons/applayout/AppHeader.java
@@ -45,8 +45,7 @@ public class AppHeader extends Component implements HasComponents {
     }
 
     public AppHeader(Image logo, String title, AppDrawer drawer) {
-    	this.getElement().setAttribute("reveals", true);
-    	this.getElement().setAttribute("condenses", true);
+    	setReveals(true);
     	this.getElement().setAttribute("effects", true);
     	appToolbar = new AppToolbar(logo, title, drawer);
     	this.add(appToolbar);
@@ -68,5 +67,14 @@ public class AppHeader extends Component implements HasComponents {
 	public void setMenuIconVisible(boolean visible) {
 		appToolbar.setMenuIconVisible(visible);
 	}
-    
+
+	/**Mantains the header fixed at the top so it never moves away.*/
+	public void setFixed(boolean fixed) {
+		this.getElement().setAttribute("fixed", fixed);
+	}
+
+	/**Slides back the header when scrolling back up.*/
+	public void setReveals(boolean reveals) {
+		this.getElement().setAttribute("reveals", reveals);
+	}
 }

--- a/src/main/java/com/flowingcode/addons/applayout/AppLayout.java
+++ b/src/main/java/com/flowingcode/addons/applayout/AppLayout.java
@@ -97,5 +97,14 @@ public class AppLayout extends Div implements PageConfigurator {
 	public void configurePage(InitialPageSettings settings) {
         settings.addMetaTag("viewport", "width=device-width, initial-scale=1.0");
 	}
-	
+
+	/**Mantains the header fixed at the top so it never moves away.*/
+	public void setFixed(boolean fixed) {
+		header.setFixed(fixed);
+	}
+
+	/**Slides back the header when scrolling back up.*/
+	public void setReveals(boolean reveals) {
+		header.setReveals(reveals);
+	}
 }

--- a/src/main/resources/META-INF/resources/frontend/styles/applayout-styles.html
+++ b/src/main/resources/META-INF/resources/frontend/styles/applayout-styles.html
@@ -44,6 +44,7 @@
 		  position: var(--layout-fixed-top_-_position); top: var(--layout-fixed-top_-_top); left: var(--layout-fixed-top_-_left); right: var(--layout-fixed-top_-_right);
 		      color: #fff;
 		      --app-header-background-rear-layer_-_background-color:  #ef6c00;;
+		  z-index: 1000;
 		}
 		
 		app-drawer {


### PR DESCRIPTION
Fixes #15 by supporting configuration of fixed (mantains the header fixed at the top so it never moves away) and reveals (slides back the header when scrolling back up). For compatibility with previous versions, the default settings are `fixed=false, reveals=true`.