### PR TITLE
Fix hilla support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <vaadin.version>23.0.9</vaadin.version>
-        <hilla.version>1.0.1</hilla.version>
+        <hilla.version>1.0.9</hilla.version>
 
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/src/main/java/com/flowingcode/addons/applayout/listener/HillaAutoConfiguration.java
+++ b/src/main/java/com/flowingcode/addons/applayout/listener/HillaAutoConfiguration.java
@@ -1,0 +1,31 @@
+package com.flowingcode.addons.applayout.listener;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.flowingcode.addons.applayout.endpoint.MenuEndpoint;
+import com.flowingcode.addons.applayout.endpoint.MenuItemsProvider;
+
+import dev.hilla.EndpointControllerConfiguration;
+import dev.hilla.EndpointRegistry;
+
+@Configuration
+@ConditionalOnClass(value = EndpointControllerConfiguration.class)
+public class HillaAutoConfiguration {
+
+	@Bean
+	public RegisterEndpointServiceInitListener registerEndpointServiceInitListener(
+			@Autowired EndpointRegistry endpointRegistry, @Autowired ApplicationContext applicationContext) {
+		return new RegisterEndpointServiceInitListener(endpointRegistry, applicationContext);
+	}
+	
+	@Bean MenuEndpoint menuEndpoint(List<MenuItemsProvider> menuItemsProviders) {
+		return new MenuEndpoint(menuItemsProviders);
+	}
+	
+}

--- a/src/main/java/com/flowingcode/addons/applayout/listener/RegisterEndpointServiceInitListener.java
+++ b/src/main/java/com/flowingcode/addons/applayout/listener/RegisterEndpointServiceInitListener.java
@@ -21,24 +21,29 @@ package com.flowingcode.addons.applayout.listener;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import org.springframework.context.ApplicationContext;
+
 import com.flowingcode.addons.applayout.endpoint.MenuEndpoint;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.stereotype.Component;
+
 import dev.hilla.Endpoint;
 import dev.hilla.EndpointRegistry;
 
-@Component
-public class RegisterEndpointServiceInitListener implements VaadinServiceInitListener, ApplicationContextAware {
+@SuppressWarnings("serial")
+public class RegisterEndpointServiceInitListener implements VaadinServiceInitListener{
 
-    private static ApplicationContext context;
+    private ApplicationContext context;
     
     private transient EndpointRegistry endpointRegistry;
 
-    @Override
+    public RegisterEndpointServiceInitListener(EndpointRegistry endpointRegistry2, ApplicationContext context) {
+		this.endpointRegistry = endpointRegistry2;
+		this.context = context;
+	}
+
+	@Override
     public void serviceInit(ServiceInitEvent event) {
         endpointRegistry = context.getBean(EndpointRegistry.class);
         context.getBeansWithAnnotation(Endpoint.class)
@@ -58,10 +63,5 @@ public class RegisterEndpointServiceInitListener implements VaadinServiceInitLis
             throw new IllegalStateException("Problem registering endpoint",e);
         }
     }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        context = applicationContext;
-    }
-    
+  
 }

--- a/src/main/resources/META-INF/resources/frontend/fc-applayout/fc-fusion-layout.ts
+++ b/src/main/resources/META-INF/resources/frontend/fc-applayout/fc-fusion-layout.ts
@@ -24,7 +24,7 @@ import {FcAppLayoutElement} from "@flowingcode/fc-applayout/src/fc-applayout";
 import "@flowingcode/fc-menuitem";
 import * as menuItemEndpoint from '@vaadin/flow-frontend/generated/MenuEndpoint';
 import MenuItemDto from '@vaadin/flow-frontend/generated/com/flowingcode/addons/applayout/endpoint/MenuItemDto';
-import { EndpointError } from 'Frontend/../target/flow-frontend';
+import { EndpointError } from '@hilla/frontend';
 import { Router } from '@vaadin/router';
 
 @customElement('fc-fusion-layout')

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.flowingcode.addons.applayout.listener.HillaAutoConfiguration


### PR DESCRIPTION
Use spring boot autoconfiguration support, based on the condition on the presence of a specific hilla class, so it won't break compatibility with non hilla project, and it will be easier to integrate with hybrid projects.