### PR TITLE
Update to 24.4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 frontend/index.html
 vite.config.ts
 vite.generated.ts
+src/main/bundles/

--- a/pom.xml
+++ b/pom.xml
@@ -9,16 +9,12 @@
     <description>Integration of app-layout for Vaadin Flow</description>
 
     <properties>
-        <vaadin.version>24.3.8</vaadin.version>
-        <hilla.version>2.5.7</hilla.version>
-
+        <vaadin.version>24.4.4</vaadin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
-
         <jetty.version>11.0.14</jetty.version>
     </properties>
     <organization>
@@ -81,10 +77,8 @@
             <optional>true</optional>
         </dependency>
 		<dependency>
-		    <groupId>dev.hilla</groupId>
-		    <artifactId>endpoint</artifactId>
-		    <version>${hilla.version}</version>
-		    <optional>true</optional>
+			<groupId>com.vaadin</groupId>
+			<artifactId>hilla</artifactId>
 		</dependency>
         <dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/flowingcode/addons/applayout/endpoint/MenuEndpoint.java
+++ b/src/main/java/com/flowingcode/addons/applayout/endpoint/MenuEndpoint.java
@@ -19,12 +19,12 @@
  */
 package com.flowingcode.addons.applayout.endpoint;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import com.flowingcode.addons.applayout.MenuItem;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
-import dev.hilla.Endpoint;
-import dev.hilla.Nonnull;
+import com.vaadin.hilla.Endpoint;
+import com.vaadin.hilla.Nonnull;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Endpoint
 @AnonymousAllowed

--- a/src/main/java/com/flowingcode/addons/applayout/endpoint/MenuItemDto.java
+++ b/src/main/java/com/flowingcode/addons/applayout/endpoint/MenuItemDto.java
@@ -19,10 +19,10 @@
  */
 package com.flowingcode.addons.applayout.endpoint;
 
+import com.vaadin.hilla.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import dev.hilla.Nonnull;
 
 public class MenuItemDto {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `src/main/bundles/`.
  - Updated project dependencies: Vaadin version updated to `24.4.4` and replaced `hilla` dependencies with `com.vaadin:hilla`.
  
- **Refactor**
  - Reorganized import statements in `MenuEndpoint` and `MenuItemDto` to use `com.vaadin.hilla` package instead of `dev.hilla`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->