### PR TITLE
docs(readme): add special configuration when using Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ app.setToolbarIconButtons(
     new ToolbarIconButton("Close", "close", ()->Notification.show("Close action"))
 );
 ```
+
+## Special configuration when using Spring
+
+By default, Vaadin Flow only includes ```com/vaadin/flow/component``` to be always scanned for UI components and views. For this reason, the add-on might need to be allowed in order to display correctly. 
+
+To do so, just add ```com.flowingcode``` to the ```vaadin.allowed-packages``` property in ```src/main/resources/application.properties```, like:
+
+```vaadin.allowed-packages = com.vaadin,org.vaadin,dev.hilla,com.flowingcode```
+ 
+More information on Spring scanning configuration [here](https://vaadin.com/docs/latest/integrations/spring/configuration/#configure-the-scanning-of-packages).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section in the README titled "Special configuration when using Spring" to guide users on configuring Vaadin Flow for proper display with Spring.
	- Included instructions for updating the `vaadin.allowed-packages` property and provided an example configuration line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->