### PR TITLE
Update web-component version to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
                 <configuration>
-                    <scanIntervalSeconds>3</scanIntervalSeconds>
+                    <scan>3</scan>
                     <!-- Use test scope because the UI/demo classes are in
                             the test package. -->
                     <useTestScope>true</useTestScope>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.addons.applayout</groupId>
     <artifactId>app-layout-addon</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <name>App Layout Addon</name>
     <description>Integration of app-layout for Vaadin Flow</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
-        <flowingcode.commons.demo.version>4.0.0</flowingcode.commons.demo.version>
+        <flowingcode.commons.demo.version>4.2.0</flowingcode.commons.demo.version>
         <jetty.version>11.0.14</jetty.version>
     </properties>
     <organization>

--- a/src/main/java/com/flowingcode/addons/applayout/AppLayout.java
+++ b/src/main/java/com/flowingcode/addons/applayout/AppLayout.java
@@ -43,7 +43,7 @@ import org.apache.commons.lang3.StringUtils;
 @SuppressWarnings("serial")
 @Tag("fc-applayout")
 @JsModule("@flowingcode/fc-applayout/fc-applayout.js")
-@NpmPackage(value = "@flowingcode/fc-applayout", version = "1.3.0")
+@NpmPackage(value = "@flowingcode/fc-applayout", version = "1.4.0")
 @CssImport(value = "./styles/applayout-styles.css", themeFor = "fc-applayout")
 public class AppLayout extends Div implements RouterLayout {
 


### PR DESCRIPTION
Version [1.4.0](https://github.com/FlowingCode/fc-applayout/releases/tag/1.4.0) of the web-component adds support for styling menu container. 

As the update on the web-component is an enhancement, version of the add-on was updated to 6.1.0-SNAPSHOT.

This PR also includes an update on the commons-demo dependency version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Bumped application version to 6.1.0-SNAPSHOT.
  * Updated AppLayout package to 1.4.0 for the embedded UI component.
  * Upgraded demo dependency to 4.2.0.
  * Adjusted development server rescan configuration for improved change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->